### PR TITLE
Measure perf of aliasing react.min.js as react

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Webpack output
+bundle.js
+bundle.*.js
+
 # Logs
 logs
 *.log

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,8 @@ echo "Raw JS:"
 node index.js 400
 echo "Uglified: "
 node bundle.js 400
+echo "Aliasing react.min.js as react: "
+node bundle.react-min.js 400
 
 echo ""
 echo "200k"
@@ -16,3 +18,5 @@ echo "Raw JS:"
 node index.js 4000
 echo "Uglified: "
 node bundle.js 4000
+echo "Aliasing react.min.js as react: "
+node bundle.react-min.js 4000

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,12 +22,27 @@ plugins.push(new webpack.optimize.UglifyJsPlugin({
     minimize: true
   }));
 
-module.exports = {
-    entry: "./index.js",
-    target: 'node',
-    plugins: plugins,
-    output: {
-        path: __dirname,
-        filename: "bundle.js"
-    }
-};
+module.exports = [
+  {
+      entry: "./index.js",
+      target: 'node',
+      plugins: plugins,
+      output: {
+          path: __dirname,
+          filename: "bundle.js"
+      }
+  },
+  {
+      entry: "./index.js",
+      target: 'node',
+      resolve: {
+        alias: {
+          react$: 'react/dist/react.min.js'
+        }
+      },
+      output: {
+          path: __dirname,
+          filename: "bundle.react-min.js"
+      }
+  }
+];


### PR DESCRIPTION
This is a technique I've seen recommended a few times, which is lower touch than uglifying your entire codebase (including dependencies) but doesn't seem to provide the same perf gains.

On my humble 2011 Macbook Air, these are the numbers from my last run:

```
20k
Raw JS:
21.11ms
Uglified:
3.17ms
Alias React.min.js as React:
13.94ms

200k
Raw JS:
182.11ms
Uglified:
30.51ms
Alias React.min.js as React:
132.64ms
```
