### PR TITLE
Decouple install and build steps from test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ### Performance test for reactjs server side rendering
 
-To run: ``./run.sh``
+```bash
+$ npm install
+$ npm test
+```
 
 This reports the server rending of a 20k and a 200k document averaged over 100
 iterations.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run build && ./run.sh",
+    "build": "webpack",
+    "start": "npm run test"
   },
   "repository": {
     "type": "git",

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-npm install
-
-./node_modules/.bin/webpack
-
 echo "20k"
 echo "Raw JS:"
 node index.js 400


### PR DESCRIPTION
I wanted to make sure that `npm install` wasn't executed on every test run, so I cleaned this up a little bit. I also wanted to be able to run the build step independently while iterating on the webpack config.
